### PR TITLE
NR module name doesn't match native code

### DIFF
--- a/NewRelicRNModule.js
+++ b/NewRelicRNModule.js
@@ -1,3 +1,3 @@
 import {NativeModules} from 'react-native';
 
-module.exports = NativeModules.NewRelicRNModule;
+module.exports = NativeModules.NewRelicModule;

--- a/android/app/src/main/java/com/rnnewrelic/NewRelicModule.java
+++ b/android/app/src/main/java/com/rnnewrelic/NewRelicModule.java
@@ -30,7 +30,7 @@ public class NewRelicModule extends ReactContextBaseJavaModule {
 
     @Override
     public String getName() {
-        return "NewRelicRNModule";
+        return "NewRelicModule";
     }
 
     @Override


### PR DESCRIPTION
[iOS](https://github.com/newrelic-experimental/NewRelicReactNativeModule/blob/master/ios/rnnewrelic/NewRelicModule.m#L5) and [android](https://github.com/newrelic-experimental/NewRelicReactNativeModule/blob/master/android/app/src/main/java/com/rnnewrelic/NewRelicModule.java#L33) don't match in module name.

If you want iOS to follow Android, this PR isn't it. We'd need to change `RCT_EXPORT_MODULE();` to `RCT_EXPORT_MODULE('NewRelicRNModule');` or rename the file accordingly; either would work.

Closes #4.