### PR TITLE
fix: Rename typo in Android platform log setup

### DIFF
--- a/android/app/src/main/java/com/rnnewrelic/NewRelicModule.java
+++ b/android/app/src/main/java/com/rnnewrelic/NewRelicModule.java
@@ -131,7 +131,7 @@ public class NewRelicModule extends ReactContextBaseJavaModule {
         }
 
         localMap.put("logLevel", loglevel);
-        localMap.put("platform", "andorid");
+        localMap.put("platform", "android");
         NewRelic.recordCustomEvent("RNError", localMap);
     }
 


### PR DESCRIPTION
I believe `andorid` is meant to mean `android` as the platform and the former is just a typo.