### PR TITLE
Fixes for the Android module

### DIFF
--- a/android/app/src/main/java/com/rnnewrelic/NewRelicModule.java
+++ b/android/app/src/main/java/com/rnnewrelic/NewRelicModule.java
@@ -112,26 +112,26 @@ public class NewRelicModule extends ReactContextBaseJavaModule {
     public void logSend(String loglevel, String message, String stack, String lineNumber, String fileName, String columnNumber, String name) {
         Map localMap = new HashMap<>();
 
-        if (stack.length() > 0) {
+        if (stack != null && stack.length() > 0) {
             localMap.put("stack", stack);
         } else {
             localMap.put("stack", "No Trace");
         }
 
-        if (name.length() > 0) {
+        if (name != null && name.length() > 0) {
             localMap.put("name", name);
         } else {
             localMap.put("name", "No Name");
         }
 
-        if (message.length() > 0) {
+        if (message != null && message.length() > 0) {
             localMap.put("message", message);
         } else {
             localMap.put("message", "No Message");
         }
 
         localMap.put("logLevel", loglevel);
-        localMap.put("platform", "andorid");
+        localMap.put("platform", "android");
         NewRelic.recordCustomEvent("RNError", localMap);
     }
 


### PR DESCRIPTION
* A missing (`null`) `stack` or other args produces an error
* `android` was misspelled for the `platform`